### PR TITLE
Add option to disable get/set xattr

### DIFF
--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -1054,6 +1054,8 @@ void show_help (void)
     "\n"
     "   nomultipart (disable multipart uploads)\n"
     "\n"
+    "   noxattr (disable xattr)\n"
+    "\n"
     "   enable_content_md5 (default is disable)\n"
     "      - ensure data integrity during writes with MD5 hash.\n"
     "\n"


### PR DESCRIPTION
对于支持[xattr](http://man7.org/linux/man-pages/man7/xattr.7.html)的文件系统，写数据的时候需要get xattr，如果在无缓存模式下，get xattr会导致大量的HEAD Object请求，拖慢文件写入的速度。(#16)

而对于大部分使用文件系统的场景，都不会用到xattr，除了[ecryptfs](http://ecryptfs.org/)。

这个PR提供一个选项，让用户可以关闭xattr相关的操作以提高性能，这意味着：

1. getxattr会返回`-ENOATTR`，忽略已设置的xattr（如果有）
2. setxattr会直接`return 0`，设置xattr将不能生效

使用方法：
```bash
./ossfs bucket-name mount-point -onoxattr
```

**使用ecryptfs的用户不能使用此选项**

参考：
- https://sourceforge.net/p/fuse/mailman/message/28384528/
- http://thread.gmane.org/gmane.linux.file-systems/44830