### PR TITLE
fix can not read/close file after rename an opened file

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -1893,6 +1893,17 @@ void FdManager::Rename(const std::string &from, const std::string &to)
     fent.erase(iter);
     ent->SetPath(to);
     fent[to] = ent;
+  } else {
+    for(fdent_map_t::iterator iter = fent.begin(); iter != fent.end(); ++iter){
+      if((*iter).second && (*iter).second->IsOpen()) {
+        // found opend fd in map
+        if(0 == strcmp((*iter).second->GetPath(), from.c_str())){
+          FdEntity* ent = (*iter).second;
+          ent->SetPath(to);
+          S3FS_PRN_DBG("rename ent[from=%s][to=%s][ent->fd=%d]", from.c_str(), to.c_str(), ent->GetFd());
+        }
+      }
+    }
   }
 }
 

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -468,6 +468,13 @@ function test_file_size_in_stat_cache {
     python $CUR_DIR/stat_cache_test.py $TEST_BUCKET_MOUNT_POINT_1
 }
 
+function test_ut_ossfs {
+    echo "Testing file size in stat cache..."
+    export TEST_BUCKET_MOUNT_POINT=$TEST_BUCKET_MOUNT_POINT_1
+    python $CUR_DIR/ut_test.py
+}
+
+
 function run_all_tests {
     test_append_file
     test_truncate_file
@@ -492,6 +499,7 @@ function run_all_tests {
     test_extended_attributes
     test_mtime_file
     test_file_size_in_stat_cache
+    test_ut_ossfs
 }
 
 # Mount the bucket

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -469,7 +469,7 @@ function test_file_size_in_stat_cache {
 }
 
 function test_ut_ossfs {
-    echo "Testing file size in stat cache..."
+    echo "Testing ossfs python ut"
     export TEST_BUCKET_MOUNT_POINT=$TEST_BUCKET_MOUNT_POINT_1
     python $CUR_DIR/ut_test.py
 }

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -469,7 +469,7 @@ function test_file_size_in_stat_cache {
 }
 
 function test_ut_ossfs {
-    echo "Testing ossfs python ut"
+    echo "Testing ossfs python ut..."
     export TEST_BUCKET_MOUNT_POINT=$TEST_BUCKET_MOUNT_POINT_1
     python $CUR_DIR/ut_test.py
 }

--- a/test/small-integration-test.sh
+++ b/test/small-integration-test.sh
@@ -85,7 +85,7 @@ stdbuf -oL -eL $OSSFS $TEST_BUCKET_1 $TEST_BUCKET_MOUNT_POINT_1 \
     -o singlepart_copy_limit=$((10 * 1024)) \
     -o url=${OSS_URL} \
     -o use_path_request_style \
-    -o dbglevel=info -f |& stdbuf -oL -eL sed -u "s/^/ossfs: /" &
+    -o dbglevel=debug -f |& stdbuf -oL -eL sed -u "s/^/ossfs: /" &
 
 retry 30 grep $TEST_BUCKET_MOUNT_POINT_1 /proc/mounts || exit 1
 

--- a/test/ut_test.py
+++ b/test/ut_test.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+import os
+import unittest
+import ConfigParser
+import random
+import sys
+import time
+
+class OssfsUnitTest(unittest.TestCase):
+    def setUp(self):
+        self.mount_point = os.environ.get('TEST_BUCKET_MOUNT_POINT')
+        print 'mount dir %s' % (self.mount_point)
+
+    def tearDown(self):
+        pass
+
+    def random_string(self, len):
+        char_set = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g']
+        list = []
+        for i in range(0, len):
+            list.append(random.choice(char_set))
+        return "".join(list)
+    
+    def test_read_file(self):
+        filename = "%s/%s" % (self.mount_point, self.random_string(10))
+        print filename
+
+        f = open(filename, 'w')
+        data = self.random_string(1000)
+        f.write(data)
+        f.close()
+        
+        f = open(filename, 'r')
+        data = f.read(100)
+        self.assertEqual(len(data), 100)
+        data = f.read(100)
+        self.assertEqual(len(data), 100)
+        f.close()
+
+    def test_rename_file(self):
+        filename1 = "%s/%s" % (self.mount_point, self.random_string(10))
+        filename2 = "%s/%s" % (self.mount_point, self.random_string(10))
+        print filename1, filename2
+
+        f = open(filename1, 'w+')
+        data1 = self.random_string(1000)
+        f.write(data1)
+
+        os.rename(filename1, filename2)
+
+        f.seek(0, 0)
+        data2 = f.read()
+        f.close()
+
+        self.assertEqual(len(data1), len(data2))
+        self.assertEqual(data1, data2)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/test/ut_test.py
+++ b/test/ut_test.py
@@ -55,6 +55,27 @@ class OssfsUnitTest(unittest.TestCase):
 
         self.assertEqual(len(data1), len(data2))
         self.assertEqual(data1, data2)
+    
+    def test_rename_file2(self):
+        filename1 = "%s/%s" % (self.mount_point, self.random_string(10))
+        filename2 = "%s/%s" % (self.mount_point, self.random_string(10))
+        print filename1, filename2
+
+        f = open(filename1, 'w')
+        data1 = self.random_string(1000)
+        f.write(data1)
+        f.close()
+
+        os.rename(filename1, filename2)
+        
+        f = open(filename2, 'r')
+        f.seek(0, 0)
+        data2 = f.read()
+        f.close()
+
+        self.assertEqual(len(data1), len(data2))
+        self.assertEqual(data1, data2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
修复rename文件后，原文件句柄不能访问的问题， 该问题会导致句柄泄漏。