### PR TITLE
disable stat cache expiration mechanism by -o stat_cache_expire=-1

### DIFF
--- a/doc/man/ossfs.1.in
+++ b/doc/man/ossfs.1.in
@@ -136,7 +136,7 @@ maximum number of entries in the stat cache and symbolic link cache.
 specify expire time (seconds) for entries in the stat cache and symbolic link cache. This expire time indicates the time since cached.
 .TP
 \fB\-o\fR stat_cache_interval_expire (default is 900)
-specify expire time (seconds) for entries in the stat cache and symbolic link cache. This expire time is based on the time from the last access time of those cache.
+specify expire time (seconds) for entries in the stat cache and symbolic link cache. This expire time is based on the time from the last access time of those cache. -1 value means disable.
 This option is exclusive with stat_cache_expire, and is left for compatibility with older versions.
 .TP
 \fB\-o\fR enable_noobj_cache (default is disable)

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4324,9 +4324,14 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             return 0;
         }
         if(is_prefix(arg, "stat_cache_expire=")){
-            time_t expr_time = static_cast<time_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), 10));
+            auto value = cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10);
+            if(value == -1){
+                StatCache::getStatCacheData()->UnsetExpireTime();
+                return 0;
+            }
+            time_t expr_time = static_cast<time_t>(value);
             StatCache::getStatCacheData()->SetExpireTime(expr_time);
-            return 0;
+            return 0; 
         }
         // [NOTE]
         // This option is for compatibility old version.

--- a/src/s3fs_help.cpp
+++ b/src/s3fs_help.cpp
@@ -151,6 +151,7 @@ static const char help_string[] =
     "      - specify expire time (seconds) for entries in the stat cache.\n"
     "        This expire time indicates the time since stat cached. and this\n"
     "        is also set to the expire time of the symbolic link cache.\n"
+    "        -1 value means disable.\n"
     "\n"
     "   stat_cache_interval_expire (default is 900)\n"
     "      - specify expire time (seconds) for entries in the stat cache(and\n"


### PR DESCRIPTION
In older version, there was no stat cache expiration mechanism, which means stat info never expires until the limit (max_stat_cache_size) is exceeded. The current version does not support disable expiration mechanism and is not compatible with the behavior of the older version.
BTW, UnsetExpireTime() has been implemented before.